### PR TITLE
Refactor: Convert ChatGPT client from lit-html to Preact

### DIFF
--- a/chatgpt/index.html
+++ b/chatgpt/index.html
@@ -57,8 +57,9 @@
     <script type="importmap">
       {
         "imports": {
-          "lit-html": "https://cdn.jsdelivr.net/npm/lit-html@3.1.3/lit-html.js",
-          "lit-html/directives/unsafe-html.js": "https://cdn.jsdelivr.net/npm/lit-html@3.1.3/directives/unsafe-html.js"
+          "preact": "https://esm.sh/preact@10.20.1",
+          "preact/": "https://esm.sh/preact@10.20.1/",
+          "htm": "https://esm.sh/htm@3.1.1"
         }
       }
     </script>

--- a/chatgpt/src/README.md
+++ b/chatgpt/src/README.md
@@ -22,7 +22,8 @@ This application allows users to:
 ## Tech Stack
 
 -   Vanilla JavaScript (ESM)
--   [lit-html](https://lit.dev/docs/v3/api/lit-html/) (via CDN) for templating.
+-   [Preact](https://preactjs.com/) (via CDN) for UI components and rendering.
+-   [htm](https://github.com/developit/htm) (via CDN) for JSX-like templating in JavaScript.
 -   [Pico.css v2](https://picocss.com/) (via CDN) for styling.
 -   Custom Markdown parser for template extraction.
 
@@ -80,12 +81,12 @@ Just a simple text prompt.
     -   `markdownParser.js`: Custom Markdown parser.
     -   `dataProvider.js`: Fetches Markdown data.
     -   `appState.js`: Manages application state.
-    -   `ui/`: Directory for UI components (lit-html based).
+    -   `ui/`: Directory for UI components (Preact and htm based).
         -   `AppShell.js`: Basic application layout (breadcrumbs).
         -   `CategoryListView.js`: Renders the list of categories.
         -   `TemplateListView.js`: Renders the list of templates in a category.
         -   `TemplateDetailView.js`: Renders the details of a single template.
-        -   `render.js`: Utility for lit-html rendering.
+        -   `render.js`: Utility for Preact rendering.
 -   `README.md`: This file.
 
 ## Notes on the Markdown Parser

--- a/chatgpt/src/main.js
+++ b/chatgpt/src/main.js
@@ -1,4 +1,5 @@
-import { html } from 'lit-html';
+import { h } from 'preact';
+import { default as htm } from 'htm';
 import { Router } from './router.js';
 import { parseMarkdown } from './markdownParser.js';
 import { fetchData, getSourceUrlFromQuery } from './dataProvider.js';
@@ -9,6 +10,7 @@ import { renderTemplateList } from './ui/TemplateListView.js';
 import { renderTemplateDetail } from './ui/TemplateDetailView.js';
 import { render } from './ui/render.js';
 
+const html = htm.bind(h);
 const contentArea = document.getElementById('content-area');
 const breadcrumbsArea = document.getElementById('breadcrumbs');
 const sourceUrlInput = document.getElementById('sourceUrlInput');

--- a/chatgpt/src/ui/AppShell.js
+++ b/chatgpt/src/ui/AppShell.js
@@ -1,5 +1,8 @@
-import { html } from 'lit-html';
+import { h } from 'preact';
+import { default as htm } from 'htm';
 import { render } from './render.js';
+
+const html = htm.bind(h);
 
 /**
  * アプリケーションシェルのパンくずリスト部分をレンダリングします。
@@ -15,7 +18,7 @@ export function renderAppShell(appState, breadcrumbsContainer) {
                     <li>
                         ${index === breadcrumbs.length - 1
                             ? html`<span aria-current="page">${crumb.name}</span>`
-                            : html`<a href="${crumb.path}">${crumb.name}</a>`
+                            : html`<a href="${crumb.path}" onClick=${(e) => handleNav(e, crumb.path)}>${crumb.name}</a>`
                         }
                     </li>
                 `)}
@@ -23,19 +26,11 @@ export function renderAppShell(appState, breadcrumbsContainer) {
         </nav>
     `;
     render(breadcrumbLinks, breadcrumbsContainer);
+}
 
-    // クリックイベントをコンテナに委任 (PicoCSSのbreadcrumbは<a>タグになる)
-    breadcrumbsContainer.querySelectorAll('a[href^="/"]').forEach(link => {
-        link.onclick = (event) => {
-            event.preventDefault();
-            // main.js の router インスタンスにアクセスする方法が必要。
-            // ここでは単純化のため window.history を直接使うか、
-            // もしくは router インスタンスを渡す必要がある。
-            // 今回は main.js で router を初期化しているので、グローバルな router インスタンスに依存するか、
-            // イベントを発行して main.js で処理するなどの方法がある。
-            // ここでは簡易的に history API を直接叩くが、実際のアプリでは router.navigateTo を呼び出すべき。
-            window.history.pushState({}, '', link.getAttribute('href'));
-            window.dispatchEvent(new PopStateEvent('popstate')); // routerに通知
-        };
-    });
+// Separate navigation handling function to keep the template cleaner
+function handleNav(event, path) {
+    event.preventDefault();
+    window.history.pushState({}, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate')); // routerに通知
 }

--- a/chatgpt/src/ui/CategoryListView.js
+++ b/chatgpt/src/ui/CategoryListView.js
@@ -1,6 +1,8 @@
-import { html } from 'lit-html';
+import { h } from 'preact';
+import { default as htm } from 'htm';
 import { render } from './render.js';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+const html = htm.bind(h);
 
 /**
  * カテゴリ一覧を表示します。
@@ -19,11 +21,11 @@ export function renderCategoryList(categories, container, router) {
         ${categories.map(category => html`
             <article>
                 <header>
-                    <a href="/category/${encodeURIComponent(category.categoryName)}" @click=${(e) => { e.preventDefault(); router.navigateTo(`/category/${encodeURIComponent(category.categoryName)}`); }}>
+                    <a href="/category/${encodeURIComponent(category.categoryName)}" onClick=${(e) => { e.preventDefault(); router.navigateTo(`/category/${encodeURIComponent(category.categoryName)}`); }}>
                         <h3>${category.categoryName}</h3>
                     </a>
                 </header>
-                ${category.description ? html`<p>${unsafeHTML(category.description.replace(/\n/g, '<br>'))}</p>` : ''}
+                ${category.description ? html`<p dangerouslySetInnerHTML=${{ __html: category.description.replace(/\n/g, '<br>') }}></p>` : null}
                  <small>${category.templates.length} template(s)</small>
             </article>
         `)}

--- a/chatgpt/src/ui/TemplateDetailView.js
+++ b/chatgpt/src/ui/TemplateDetailView.js
@@ -1,6 +1,8 @@
-import { html, nothing } from 'lit-html';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { h } from 'preact';
+import { default as htm } from 'htm';
 import { render } from './render.js';
+
+const html = htm.bind(h);
 
 /**
  * 選択されたテンプレートの詳細（説明、プロンプト本体、変数入力欄）を表示します。
@@ -70,7 +72,7 @@ export function renderTemplateDetail(template, container) {
             <header>
                 <h3>${template.templateName}</h3>
             </header>
-            ${template.description ? html`<section class="description">${unsafeHTML(template.description.replace(/\n/g, '<br>'))}</section>` : nothing}
+            ${template.description ? html`<section class="description" dangerouslySetInnerHTML=${{ __html: template.description.replace(/\n/g, '<br>') }}></section>` : null}
             
             ${uniquePlaceholders.length > 0 ? html`
                 <section class="placeholders">
@@ -81,8 +83,8 @@ export function renderTemplateDetail(template, container) {
                             <textarea
                                 id="ph-${ph}"
                                 name="${ph}"
-                                .value=${placeholderValues[ph]}
-                                @input=${(e) => updatePlaceholderValue(ph, e.target.value)}
+                                value=${placeholderValues[ph]}
+                                onInput=${(e) => updatePlaceholderValue(ph, e.target.value)}
                                 placeholder="Enter value for ${ph}"
                                 rows="3"
                                 style="width:100%"
@@ -90,25 +92,25 @@ export function renderTemplateDetail(template, container) {
                         </div>
                     `)}
                 </section>
-            ` : nothing}
+            ` : null}
 
             <h4>Prompt Template(s):</h4>
             ${template.prompts.map((prompt, index) => html`
                 <div class="template-body-container">
-                    ${prompt.language ? html`<small>Language: ${prompt.language}</small>` : nothing}
+                    ${prompt.language ? html`<small>Language: ${prompt.language}</small>` : null}
                     <button 
                         class="copy-button outline"
-                        @click=${(e) => copyToClipboard(getProcessedPromptBody(prompt.body), e.target)}>
+                        onClick=${(e) => copyToClipboard(getProcessedPromptBody(prompt.body), e.target)}>
                         Copy
                     </button>
                     <pre><code>${getProcessedPromptBody(prompt.body)}</code></pre>
                 </div>
-                ${index < template.prompts.length - 1 ? html`<hr>` : nothing}
+                ${index < template.prompts.length - 1 ? html`<hr />` : null}
             `)}
             
             <footer>
                 <a href="/category/${encodeURIComponent(template.categoryName)}" 
-                   @click=${(e) => { 
+                   onClick=${(e) => {
                        e.preventDefault(); 
                        // This requires access to the router instance from main.js
                        // For now, using history API directly and dispatching event

--- a/chatgpt/src/ui/TemplateListView.js
+++ b/chatgpt/src/ui/TemplateListView.js
@@ -1,6 +1,8 @@
-import { html } from 'lit-html';
+import { h } from 'preact';
+import { default as htm } from 'htm';
 import { render } from './render.js';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+const html = htm.bind(h);
 
 /**
  * 特定のカテゴリに属するテンプレートの一覧を表示します。
@@ -10,7 +12,7 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
  */
 export function renderTemplateList(category, container, router) {
     if (!category || !category.templates || category.templates.length === 0) {
-        render(html`<p>No templates found in this category.</p><a href="/">Back to Categories</a>`, container);
+        render(html`<p>No templates found in this category.</p><a href="/" onClick=${(e) => { e.preventDefault(); router.navigateTo('/'); }}>Back to Categories</a>`, container);
         return;
     }
 
@@ -20,14 +22,14 @@ export function renderTemplateList(category, container, router) {
             <article>
                 <header>
                     <a href="/category/${encodeURIComponent(category.categoryName)}/template/${encodeURIComponent(template.templateName)}" 
-                       @click=${(e) => { e.preventDefault(); router.navigateTo(`/category/${encodeURIComponent(category.categoryName)}/template/${encodeURIComponent(template.templateName)}`); }}>
+                       onClick=${(e) => { e.preventDefault(); router.navigateTo(`/category/${encodeURIComponent(category.categoryName)}/template/${encodeURIComponent(template.templateName)}`); }}>
                         <h4>${template.templateName}</h4>
                     </a>
                 </header>
-                ${template.description ? html`<p>${unsafeHTML(template.description.replace(/\n/g, '<br>'))}</p>` : ''}
+                ${template.description ? html`<p dangerouslySetInnerHTML=${{ __html: template.description.replace(/\n/g, '<br>') }}></p>` : null}
             </article>
         `)}
-        <p><a href="/" @click=${(e) => { e.preventDefault(); router.navigateTo('/'); }}>Back to Categories</a></p>
+        <p><a href="/" onClick=${(e) => { e.preventDefault(); router.navigateTo('/'); }}>Back to Categories</a></p>
     `;
     render(templateList, container);
 }

--- a/chatgpt/src/ui/render.js
+++ b/chatgpt/src/ui/render.js
@@ -1,11 +1,10 @@
-import { html } from 'lit-html';
-import { render as litRender } from 'lit-html';
+import { render as preactRender, h } from 'preact';
 
 /**
- * lit-htmlのrender関数をラップし、指定されたコンテナにUIを描画します。
- * @param {import('https://cdn.jsdelivr.net/npm/lit-html@3.1.3/lit-html.js').TemplateResult | undefined} templateResult - レンダリングするlit-htmlテンプレート
+ * Preactのrender関数をラップし、指定されたコンテナにUIを描画します。
+ * @param {import('preact').VNode | undefined} vnode - レンダリングするPreact VNode
  * @param {HTMLElement} container - 描画先のコンテナ要素
  */
-export function render(templateResult, container) {
-    litRender(templateResult, container);
+export function render(vnode, container) {
+    preactRender(vnode, container);
 }


### PR DESCRIPTION
This commit refactors the ChatGPT client application's frontend from lit-html to Preact.

Key changes include:
- Updated `index.html` to use an import map for Preact and htm.
- Modified `src/ui/render.js` to use Preact's rendering logic.
- Refactored all UI components in `src/ui/` (AppShell, CategoryListView, TemplateDetailView, TemplateListView) to use Preact and htm for templating. This involved:
    - Replacing lit-html's `html` and `nothing` with Preact/htm equivalents.
    - Converting `unsafeHTML` directives to Preact's `dangerouslySetInnerHTML`.
    - Updating event handling (e.g., `@click` to `onClick`).
- Updated `src/main.js` to use Preact/htm for its inline templates.
- Updated `src/README.md` to reflect the new tech stack (Preact and htm).

The goal of this refactor is to modernize the frontend stack while maintaining existing functionality. The application now uses Preact for its component model and htm for efficient, JSX-like templating directly in JavaScript modules.