### PR TITLE
feat: Enable dynamic loading of markdown via URL parameter

### DIFF
--- a/chatgpt/src/appState.js
+++ b/chatgpt/src/appState.js
@@ -1,7 +1,11 @@
+import { getSourceUrlFromQuery } from './dataProvider.js';
+
 /**
  * @typedef {import('./markdownParser.js').ParsedCategory} ParsedCategory
  * @typedef {import('./markdownParser.js').ParsedTemplate} ParsedTemplate
  */
+
+const DEFAULT_SOURCE_URL = "https://raw.githubusercontent.com/podhmo/podhmo.github.io/refs/heads/master/chatgpt/Template.md";
 
 /**
  * アプリケーションの状態を管理します。
@@ -12,6 +16,8 @@ export class AppState {
         this.data = null;
         /** @type {string} */
         this.currentPath = '/'; // 例: '/', '/category/ChatGPT', '/category/ChatGPT/template/Prompt1'
+        /** @type {string} */
+        this.currentSourceUrl = getSourceUrlFromQuery() || DEFAULT_SOURCE_URL;
     }
 
     /**
@@ -28,6 +34,19 @@ export class AppState {
      */
     setCurrentPath(path) {
         this.currentPath = path;
+    }
+
+    getCurrentSourceUrl() {
+        return this.currentSourceUrl;
+    }
+
+    setCurrentSourceUrl(url) {
+        if (url && typeof url === 'string') {
+            this.currentSourceUrl = url;
+        } else {
+            console.warn("Attempted to set invalid source URL:", url);
+            this.currentSourceUrl = DEFAULT_SOURCE_URL; // Fallback to default
+        }
     }
 
     /**

--- a/chatgpt/src/main.js
+++ b/chatgpt/src/main.js
@@ -186,6 +186,6 @@ class App {
 
 // アプリケーションインスタンスを作成して開始
 const currentBasePath = globalThis.location.pathname.replace(/\/[^/]*$/, '');
-// console.log(`Current base path: ${currentBasePath}`); // removed console.log
+console.log(`Current base path: ${currentBasePath}`);
 const app = new App(document.getElementById('app'), currentBasePath);
 app.start();

--- a/chatgpt/src/main.js
+++ b/chatgpt/src/main.js
@@ -2,7 +2,8 @@ import { h } from 'preact';
 import { default as htm } from 'htm';
 import { Router } from './router.js';
 import { parseMarkdown } from './markdownParser.js';
-import { fetchData, getSourceUrlFromQuery } from './dataProvider.js';
+// getSourceUrlFromQuery removed
+import { fetchData } from './dataProvider.js';
 import { AppState } from './appState.js';
 import { AppShell } from './ui/AppShell.js';
 import { CategoryListView } from './ui/CategoryListView.js';
@@ -12,10 +13,6 @@ import { render } from './ui/render.js';
 import { AppRootComponent } from './ui/AppRootComponent.js';
 
 const html = htm.bind(h);
-// const contentArea = document.getElementById('content-area'); // Removed
-// const breadcrumbsArea = document.getElementById('breadcrumbs'); // Removed
-// const sourceUrlInput = document.getElementById('sourceUrlInput'); // Removed
-// const loadSourceUrlButton = document.getElementById('loadSourceUrlButton'); // Removed
 
 /**
  * @typedef {import('./markdownParser.js').ParsedCategory} ParsedCategory
@@ -36,21 +33,30 @@ class App {
         this.appState = new AppState();
         this.router = new Router(basePath);
         this.currentBreadcrumbsVNode = null;
-        this.currentMainContentVNode = html`<p>Initializing...</p>`; // Initial content
+        this.currentMainContentVNode = html`<p>Initializing...</p>`;
         this.setupRoutes();
-        // setupEventListeners is effectively replaced by passing handleLoadSourceUrl to AppRootComponent
     }
 
-    handleLoadSourceUrl(url) {
-        if (url) {
-            const newUrl = new URL(globalThis.location.href);
-            newUrl.searchParams.set('source', url);
-            globalThis.location.href = newUrl.toString();
+    async handleLoadSourceUrl(newUrl) {
+        if (newUrl && typeof newUrl === 'string' && newUrl.trim() !== '') {
+            const trimmedUrl = newUrl.trim();
+            this.appState.setCurrentSourceUrl(trimmedUrl);
+            const newBrowserUrl = new URL(window.location.origin + window.location.pathname);
+            newBrowserUrl.searchParams.set('source', trimmedUrl);
+            history.pushState({}, '', newBrowserUrl.toString());
+
+            this.currentMainContentVNode = html`<p>Loading from new source: ${trimmedUrl}...</p>`;
+            this.renderUI();
+
+            await this.loadData(trimmedUrl);
+            await this.router.handleLocationChange();
+        } else {
+            console.warn("handleLoadSourceUrl called with invalid URL:", newUrl);
         }
     }
 
     renderUI() {
-        const currentSourceUrl = getSourceUrlFromQuery() || "https://raw.githubusercontent.com/podhmo/podhmo.github.io/refs/heads/master/chatgpt/Template.md";
+        const currentSourceUrl = this.appState.getCurrentSourceUrl();
         render(
             html`
                 <${AppRootComponent}
@@ -72,18 +78,18 @@ class App {
             this.appState.setCurrentPath('/');
             this.currentBreadcrumbsVNode = AppShell(this.appState, this.router);
             this.currentMainContentVNode = html`<p>Loading categories...</p>`;
-            this.renderUI(); // Initial render with loading message
+            this.renderUI();
 
-            if (!this.appState.data) await this.loadData();
-
-            if (this.appState.data) {
-                this.currentMainContentVNode = CategoryListView(this.appState.data, this.router);
-            } else {
-                 // loadData will set error message if needed, or we can set a default one here
-                if (!this.currentMainContentVNode) { // check if loadData set an error
-                    this.currentMainContentVNode = html`<p>No categories loaded.</p>`;
-                }
+            if (!this.appState.data || !this.appState.data.sourceUrl || this.appState.data.sourceUrl !== this.appState.getCurrentSourceUrl()) {
+                await this.loadData();
             }
+
+            if (this.appState.data && this.appState.data.length > 0) {
+                this.currentMainContentVNode = CategoryListView(this.appState.data, this.router);
+            } else if (this.appState.data && this.appState.data.length === 0) { // Check after data load
+                 this.currentMainContentVNode = html`<p>No templates found in the loaded source: ${this.appState.getCurrentSourceUrl()}.</p>`;
+            }
+            // Error messages from loadData take precedence and are set in this.currentMainContentVNode by loadData itself.
             this.renderUI();
         });
 
@@ -94,14 +100,23 @@ class App {
             this.currentMainContentVNode = html`<p>Loading templates for ${categoryName}...</p>`;
             this.renderUI();
 
-            if (!this.appState.data) await this.loadData();
+            if (!this.appState.data || !this.appState.data.sourceUrl || this.appState.data.sourceUrl !== this.appState.getCurrentSourceUrl()) {
+                await this.loadData();
+            }
 
-            const category = this.appState.getCategoryByName(categoryName);
-            if (category) {
-                this.currentMainContentVNode = TemplateListView(category, this.router);
-            } else {
-                this.currentMainContentVNode = html`<p>Category not found: ${categoryName}</p>`;
-                // Optional: this.router.navigateTo('/'); // or let user see the message
+            if (this.appState.data) { // Check if data is available
+                const category = this.appState.getCategoryByName(categoryName);
+                if (category) {
+                    this.currentMainContentVNode = TemplateListView(category, this.router);
+                } else {
+                    // Only set category not found if data was successfully loaded (i.e., not an error message already)
+                    if (this.appState.data.sourceUrl === this.appState.getCurrentSourceUrl() && this.appState.data.length > 0) {
+                         this.currentMainContentVNode = html`<p>Category not found: ${categoryName}</p>`;
+                    } else if (this.appState.data.length === 0 && this.appState.data.sourceUrl === this.appState.getCurrentSourceUrl()){
+                        this.currentMainContentVNode = html`<p>No data loaded from ${this.appState.getCurrentSourceUrl()}, so cannot find category ${categoryName}.</p>`;
+                    }
+                    // If loadData set an error, that message will persist.
+                }
             }
             this.renderUI();
         });
@@ -114,66 +129,63 @@ class App {
             this.currentMainContentVNode = html`<p>Loading template ${templateName}...</p>`;
             this.renderUI();
 
-            if (!this.appState.data) await this.loadData();
+            if (!this.appState.data || !this.appState.data.sourceUrl || this.appState.data.sourceUrl !== this.appState.getCurrentSourceUrl()) {
+                await this.loadData();
+            }
 
-            const template = this.appState.getTemplateByName(categoryName, templateName);
-            if (template) {
-                // TemplateDetailView needs a way to trigger re-render on placeholder input
-                // Passing this.renderUI.bind(this) as the requestRender callback
-                this.currentMainContentVNode = TemplateDetailView(template, this.router, this.renderUI.bind(this));
-            } else {
-                this.currentMainContentVNode = html`<p>Template not found: ${templateName}</p>`;
-                // Optional: this.router.navigateTo('/');
+            if (this.appState.data) { // Check if data is available
+                const template = this.appState.getTemplateByName(categoryName, templateName);
+                if (template) {
+                    this.currentMainContentVNode = TemplateDetailView(template, this.router, this.renderUI.bind(this));
+                } else {
+                     // Similar to category route, only set if data loaded correctly but template not found.
+                    if (this.appState.data.sourceUrl === this.appState.getCurrentSourceUrl() && this.appState.data.length > 0) {
+                        this.currentMainContentVNode = html`<p>Template not found: ${templateName}</p>`;
+                    } else if (this.appState.data.length === 0 && this.appState.data.sourceUrl === this.appState.getCurrentSourceUrl()){
+                        this.currentMainContentVNode = html`<p>No data loaded from ${this.appState.getCurrentSourceUrl()}, so cannot find template ${templateName}.</p>`;
+                    }
+                    // If loadData set an error, that message will persist.
+                }
             }
             this.renderUI();
         });
     }
 
-    /**
-     * Markdownデータをロードし、パースして状態に保存します。
-     */
-    async loadData() {
+    async loadData(urlToLoad = null) {
+        const currentLoadingUrl = urlToLoad || this.appState.getCurrentSourceUrl();
+
+        if (this.appState.data && this.appState.data.sourceUrl !== currentLoadingUrl) {
+            this.appState.setData(null);
+        }
+
+        this.currentMainContentVNode = html`<p>Fetching data from ${currentLoadingUrl}...</p>`;
+        // The caller (route handler or handleLoadSourceUrl) is responsible for calling renderUI to show this.
+
         try {
-            const defaultUrl = "https://raw.githubusercontent.com/podhmo/podhmo.github.io/refs/heads/master/chatgpt/Template.md";
-            // currentSourceUrl is now managed by AppRootComponent's prop for display,
-            // but getSourceUrlFromQuery is still the source of truth for loading.
-            const currentLoadingUrl = getSourceUrlFromQuery() || defaultUrl;
-            // sourceUrlInput.value = currentSourceUrl; // Removed: input is in AppRootComponent
-
-            // Set loading state for main content if not already set by router
-            if (!this.currentMainContentVNode || this.currentMainContentVNode.type === 'p') { // basic check if it's a loading msg
-                 this.currentMainContentVNode = html`<p>Fetching data from ${currentLoadingUrl}...</p>`;
-                 this.renderUI();
-            }
-
             const markdownText = await fetchData(currentLoadingUrl);
             const parsedData = parseMarkdown(markdownText);
+            parsedData.sourceUrl = currentLoadingUrl;
             this.appState.setData(parsedData);
-            if (parsedData.length === 0) {
-                 this.currentMainContentVNode = html`<p>No templates found in the loaded source. Try a different URL.</p>`;
-                 // this.renderUI() will be called by the route handler after loadData completes
-            }
-            // Data is set, route handler will call renderUI with new content
+
+            // Let route handlers determine content for empty data, do not set currentMainContentVNode here for that case.
         } catch (error) {
-            console.error('Error loading or parsing data:', error);
-            this.currentMainContentVNode = html`<p>Error loading data: ${error.message}. Please check the console and the Markdown source.</p>`;
-            this.appState.setData([]); // エラー時は空データ
-            // this.renderUI() will be called by the route handler
+            console.error('Error loading or parsing data from ${currentLoadingUrl}:', error);
+            this.currentMainContentVNode = html`<p>Error loading data from ${currentLoadingUrl}: ${error.message}. Please check the console and the Markdown source.</p>`;
+            const errorData = [];
+            errorData.sourceUrl = currentLoadingUrl;
+            this.appState.setData(errorData);
         }
     }
 
-    /**
-     * アプリケーションを開始します。
-     */
     async start() {
-        this.currentMainContentVNode = html`<p>Application starting...</p>`; // Initial message
-        this.renderUI(); // Render initial state of AppRootComponent
-        await this.router.handleLocationChange(); // 初期ルート処理, this will call renderUI again
+        this.currentMainContentVNode = html`<p>Application starting...</p>`;
+        this.renderUI();
+        await this.router.handleLocationChange();
     }
 }
 
 // アプリケーションインスタンスを作成して開始
 const currentBasePath = globalThis.location.pathname.replace(/\/[^/]*$/, '');
-console.log(`Current base path: ${currentBasePath}`);
+// console.log(`Current base path: ${currentBasePath}`); // removed console.log
 const app = new App(document.getElementById('app'), currentBasePath);
 app.start();


### PR DESCRIPTION
This change modifies the ChatGPT prompt template page to allow you to load markdown content from a URL specified in an input field.

Key changes:
- The 'Load' button now fetches markdown from the provided URL without a full page reload.
- The browser's URL is updated with a 'source' query parameter using history.pushState, allowing sharing and refreshing.
- AppState now manages the current source URL.
- Main application logic in App class (main.js) was updated to handle data loading from dynamic sources, update UI accordingly, and manage history.
- Error handling for invalid URLs or fetch failures is included.
- Default template loading and navigation within a loaded template remain functional.