### PR TITLE
Feat: Highlight template variables in preview

### DIFF
--- a/chatgpt/index.html
+++ b/chatgpt/index.html
@@ -33,6 +33,18 @@
         .placeholder-input label {
             margin-right: 0.5em;
         }
+        .template-body-container {
+          background-color: #ccc;
+          color: #333;
+          padding: 1rem;
+          border-radius: 0.5rem;
+          margin-bottom: 1rem;
+        }
+        .template-body-container mark {
+          background-color: #ffdd57;
+          padding: 0.2em;
+          border-radius: 0.3em;
+        }
     </style>
 </head>
 <body>

--- a/chatgpt/src/ui/TemplateDetailView.js
+++ b/chatgpt/src/ui/TemplateDetailView.js
@@ -99,17 +99,18 @@ ${instruction}
         uniquePlaceholders.forEach(phObj => {
             const placeholderRegex = new RegExp(`\\{\\{${phObj.name}(?::[^}]+)?\\}\\}`, 'g');
             let valueToReplace = placeholderValues[phObj.name];
+            let replacementText;
+
             if (valueToReplace === undefined) { // Should not happen if initialized correctly
-                valueToReplace = phObj.defaultValue !== null ? phObj.defaultValue : `{{${phObj.name}}}`;
+                replacementText = phObj.defaultValue !== null ? `<mark>${phObj.defaultValue}</mark>` : `{{${phObj.name}}}`;
             } else if (valueToReplace === '' && phObj.defaultValue !== null) {
-                valueToReplace = phObj.defaultValue;
+                replacementText = `<mark>${phObj.defaultValue}</mark>`;
             } else if (valueToReplace === '' && phObj.defaultValue === null) {
-                // Task: "Keep placeholder if value is empty" - this was in old code.
-                // For new logic: if value is empty and no default, it means user wants it empty, or it was empty initially.
-                // The prompt asks for {{name}} to be output if value is empty and no default.
-                 valueToReplace = `{{${phObj.name}}}`;
+                replacementText = `{{${phObj.name}}}`;
+            } else {
+                replacementText = `<mark>${valueToReplace}</mark>`;
             }
-            processedBody = processedBody.replace(placeholderRegex, valueToReplace);
+            processedBody = processedBody.replace(placeholderRegex, replacementText);
         });
         return processedBody;
     };
@@ -207,7 +208,7 @@ ${instruction}
                         onClick=${(e) => copyToClipboard(getProcessedPromptBody(prompt.body), e.target)}>
                         Copy
                     </button>
-                    <pre><code>${getProcessedPromptBody(prompt.body)}</code></pre>
+                    <pre><code dangerouslySetInnerHTML=${{ __html: getProcessedPromptBody(prompt.body) }}></code></pre>
                 </div>
                 ${index < template.prompts.length - 1 ? html`<hr />` : null}
             `)}


### PR DESCRIPTION
- I modified `TemplateDetailView.js` to wrap placeholder values in `<mark>` tags.
- I used `dangerouslySetInnerHTML` to render the highlighted variables in the template preview.
- This improves your ability to distinguish between static text and variable parts of the template.