### PR TITLE
Fix: Template variables now update correctly when copied

### DIFF
--- a/chatgpt/src/appState.js
+++ b/chatgpt/src/appState.js
@@ -18,6 +18,17 @@ export class AppState {
         this.currentPath = '/'; // 例: '/', '/category/ChatGPT', '/category/ChatGPT/template/Prompt1'
         /** @type {string} */
         this.currentSourceUrl = getSourceUrlFromQuery() || DEFAULT_SOURCE_URL;
+        /** @type {Object<string, string>} */
+        this.templateVariableValues = {};
+    }
+    setVariableValue(name, value) {
+        this.templateVariableValues[name] = value;
+    }
+    getVariableValues() {
+        return this.templateVariableValues;
+    }
+    clearVariableValues() {
+        this.templateVariableValues = {};
     }
 
     /**


### PR DESCRIPTION
The previous implementation had a state management issue where template variables were stored in a local, ephemeral state within the `TemplateDetailView` component. This caused your input to be lost on re-renders, so the value you copied to the clipboard was the original default value, not your updated value.

This commit refactors the state management for template variables:

1.  **Lifted State Up**: The state for template variables has been moved from `TemplateDetailView` to the global `AppState`. This provides a single source of truth.
2.  **Reactive Re-rendering**: The rendering logic in `main.js` has been updated to force a full re-render of `TemplateDetailView` whenever a variable changes. This ensures the UI (including the `<pre>` block) and the data for the copy action are always in sync with the latest state.
3.  **State Lifecycle**: The state is now correctly initialized when a template is loaded and cleared when navigating to a new template.